### PR TITLE
[pod-reloader] registry secret template fix

### DIFF
--- a/templates/registry-secret.yaml
+++ b/templates/registry-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.podReloader.registry }}
 ---
 apiVersion: v1
 kind: Secret
@@ -7,4 +8,5 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson: {{ .Values.podReloader.registry.dockercfg }}
+{{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Change registry secret from internal module template to external module template

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
