### PR TITLE
Fix check previous release

### DIFF
--- a/.github/check_previous_channel_release.sh
+++ b/.github/check_previous_channel_release.sh
@@ -28,7 +28,7 @@ fi
 
 echo "Checking previous channel $previousChannel"
 $crane auth login -u $user -p $password registry.deckhouse.io
-previousChannelVersion=$($crane export registry.deckhouse.io/deckhouse/$edition/modules/$repositoryName/release:$previousChannel | grep -aoE '\{"version":".*"\}' | jq -r .version)
+previousChannelVersion=$($crane export registry.deckhouse.io/deckhouse/$edition/modules/$repositoryName/release:$previousChannel | tar -xOf - version.json | jq -r .version)
 if [[ "$version" == "$previousChannelVersion" ]]; then
  echo "Previous channel $previousChannel version $previousChannelVersion is equal desired version $version, processing"
  exit 0


### PR DESCRIPTION
## Description
This PR fixes breaked pipelines (example https://github.com/deckhouse/pod-reloader/actions/runs/16989926367/job/48166792395)
Pipeline error:
```
Previous channel alpha version  is not equal desired version v1.0.2, rejecting
Error: Process completed with exit code 1.
```
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
