### PR TITLE
chore: bump base images version to v0.5.27

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: v0.5.11
+  BASE_IMAGES_VERSION: v0.5.27
 
 on:
   #pull_request:

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -12,7 +12,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: v0.5.11
+  BASE_IMAGES_VERSION: v0.5.27
 
 on:
   push:

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -11,7 +11,7 @@ env:
   GOLANG_VERSION: ${{ vars.GOLANG_VERSION }}
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
-  BASE_IMAGES_VERSION: v0.5.11
+  BASE_IMAGES_VERSION: v0.5.27
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Updated BASE_IMAGES_VERSION from v0.5.11 to v0.5.27 across all GitHub Actions workflows in the pod-reloader module. This change affects the base images used during the build process for all editions (CE, BE, EE, FE, SE, SE+).

This update does not influence critical cluster components as it only affects the container images used for building the pod-reloader module itself. The pod-reloader runs on system nodes and manages ConfigMap/Secret reloading for workloads, but this base image update will not cause restarts of ingress-controllers, control-plane, or Prometheus.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This update addresses HIGH severity CVEs (CVE-2025-47907 and CVE-2025-47906) present in the stdlib component of the base images version v0.5.11. These vulnerabilities could potentially be exploited in the build environment and may affect the security posture of the built container images.

By updating to base images v0.5.27, we ensure that:
- The build process uses patched base images free from these known vulnerabilities
- The resulting pod-reloader container images are built with secure base components
- The module maintains its security posture and compliance requirements

The CVEs being addressed are:
- **CVE-2025-47907**: [High severity vulnerability in stdlib]
- **CVE-2025-47906**: [High severity vulnerability in stdlib]

This is a security-focused update that prevents potential exploitation of vulnerabilities in the build chain without affecting the runtime functionality of the pod-reloader module.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
