### PR TITLE
remove dev1 prerelease tag check

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -33,7 +33,7 @@ on:
         description: Rock-solid
 
       tag:
-        description: "The module's tag, which must include the -dev1 postfix. For example: v1.21.1-dev1"
+        description: "The module's tag, which must include the  postfix. For example: v1.21.1"
         type: string
         required: true
 
@@ -59,7 +59,7 @@ jobs:
         shell: bash
       - name: Validation for tag
         run: |
-          echo ${{ github.event.inputs.tag }} | grep -P '^v\d+\.\d+\.\d+-dev1$'
+          echo ${{ github.event.inputs.tag }} | grep -P '^v\d+\.\d+\.\d+$'
         shell: bash
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove useless adding pre-release tag dev1 from dev images

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
