### PR TITLE
[pod-reloader] fix CVE go bump

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: v0.5.27
+  BASE_IMAGES_VERSION: v0.5.39
 
 on:
   #pull_request:

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -12,7 +12,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: v0.5.27
+  BASE_IMAGES_VERSION: v0.5.39
 
 on:
   push:

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -11,7 +11,7 @@ env:
   GOLANG_VERSION: ${{ vars.GOLANG_VERSION }}
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
-  BASE_IMAGES_VERSION: v0.5.27
+  BASE_IMAGES_VERSION: v0.5.39
 
 on:
   workflow_dispatch:

--- a/.werf/consts.yaml
+++ b/.werf/consts.yaml
@@ -3,6 +3,6 @@
 
 # component versions
 {{- $versions := dict }}
-{{- $_ := set $versions "POD_RELOADER" "chart-v2.2.4" }}
+{{- $_ := set $versions "POD_RELOADER" "v1.4.10" }}
 
 {{- $_ := set . "VERSIONS" $versions }}

--- a/.werf/consts.yaml
+++ b/.werf/consts.yaml
@@ -3,6 +3,6 @@
 
 # component versions
 {{- $versions := dict }}
-{{- $_ := set $versions "POD_RELOADER" "v1.4.5" }}
+{{- $_ := set $versions "POD_RELOADER" "chart-v2.2.4" }}
 
 {{- $_ := set . "VERSIONS" $versions }}

--- a/module.yaml
+++ b/module.yaml
@@ -1,4 +1,6 @@
 name: pod-reloader
+descriptions:
+  en: "The module utilizes Reloader. It provides the ability for automatic rollout on ConfigMap or Secret changes. The module uses annotations for operating. The module is running on **system** nodes."
 weight: 900
 stage: "General Availability"
 subsystems:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Bump base images to 0.5.39
Bump reloader version to v1.4.10 (fixed CVE with stdlib)
Fixed dmt

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
