### PR TITLE
[pod-reloader] fix CVE: bump go 1.25.5

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: v0.5.39
+  BASE_IMAGES_VERSION: v0.5.44
 
 on:
   #pull_request:

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -12,7 +12,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: v0.5.39
+  BASE_IMAGES_VERSION: v0.5.44
 
 on:
   push:

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -11,7 +11,7 @@ env:
   GOLANG_VERSION: ${{ vars.GOLANG_VERSION }}
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
-  BASE_IMAGES_VERSION: v0.5.39
+  BASE_IMAGES_VERSION: v0.5.44
 
 on:
   workflow_dispatch:

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -48,7 +48,7 @@ jobs:
           dev_registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           dev_registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
           deckhouse_private_repo: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
-          severity: "HIGH,CRITICAL"
+          severity: "LOW,MEDIUM,HIGH,CRITICAL"
   cve_scan:
     if: github.event_name != 'pull_request'
     name: Regular CVE scan

--- a/images/pod-reloader/patches/001-go-mod.patch
+++ b/images/pod-reloader/patches/001-go-mod.patch
@@ -1,12 +1,12 @@
 diff --git a/go.mod b/go.mod
-index c630aac..263dec4 100644
+index c630aac..05edecc 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -1,21 +1,21 @@
  module github.com/stakater/Reloader
  
 -go 1.24.4
-+go 1.25.3
++go 1.25.5
  
  require (
 -	github.com/argoproj/argo-rollouts v1.8.2
@@ -37,13 +37,6 @@ index c630aac..263dec4 100644
  	github.com/x448/float16 v0.8.4 // indirect
  	golang.org/x/net v0.39.0 // indirect
  	golang.org/x/oauth2 v0.29.0 // indirect
-@@ -91,4 +91,4 @@ replace (
- 	k8s.io/sample-apiserver v0.0.0 => k8s.io/sample-apiserver v0.24.2
- 	k8s.io/sample-cli-plugin v0.0.0 => k8s.io/sample-cli-plugin v0.24.2
- 	k8s.io/sample-controller v0.0.0 => k8s.io/sample-controller v0.24.2
--)
-+)
-\ No newline at end of file
 diff --git a/go.sum b/go.sum
 index 126602f..5cb705c 100644
 --- a/go.sum


### PR DESCRIPTION
## Description
Bump base images and go version to fix CVEs:
- CVE-2025-61727
- CVE-2025-61729
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
