### PR TITLE
[chore] Bump go version

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: v0.5.44
+  BASE_IMAGES_VERSION: v0.5.55
 
 on:
   #pull_request:

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -12,7 +12,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: v0.5.44
+  BASE_IMAGES_VERSION: v0.5.55
 
 on:
   push:

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -11,7 +11,7 @@ env:
   GOLANG_VERSION: ${{ vars.GOLANG_VERSION }}
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
-  BASE_IMAGES_VERSION: v0.5.44
+  BASE_IMAGES_VERSION: v0.5.55
 
 on:
   workflow_dispatch:

--- a/images/pod-reloader/patches/001-go-mod.patch
+++ b/images/pod-reloader/patches/001-go-mod.patch
@@ -1,12 +1,12 @@
 diff --git a/go.mod b/go.mod
-index c630aac..05edecc 100644
+index c630aac..3ea5495 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -1,21 +1,21 @@
  module github.com/stakater/Reloader
  
 -go 1.24.4
-+go 1.25.5
++go 1.25.7
  
  require (
 -	github.com/argoproj/argo-rollouts v1.8.2

--- a/oss.yaml
+++ b/oss.yaml
@@ -3,3 +3,5 @@
   description: Reloader watches for ConfigMap and Secret and detects if there are changes in data of these objects. After change detection reloader performs rolling upgrade on relevant Pods via associated Deployment, DaemonSet and StatefulSet.
   logo: https://raw.githubusercontent.com/stakater/Reloader/refs/heads/master/assets/web/reloader.jpg
   license: Apache License 2.0
+  version: v1.4.5
+  id: pod-reloader

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     kind: Deployment
     name: pod-reloader
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
     - containerName: "manager"


### PR DESCRIPTION

## Description
Changes made:
- Updated BASE_IMAGES_VERSION in build_dev.yml, build_prod.yml, and deploy_dev.yml to v0.5.55.
- Bumped Go version in go.mod from 1.25.5 to 1.25.7.


<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Bump go version to fix CVEs
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
