### PR TITLE
[pod-reloader] Enable restricted pod security policy for the module namespace

### DIFF
--- a/templates/namespace.yaml
+++ b/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true" "security.deckhouse.io/pod-policy" "restricted" "security.deckhouse.io/enable-security-policy-check" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/templates/namespace.yaml
+++ b/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true" "security.deckhouse.io/pod-policy" "restricted" "security.deckhouse.io/enable-security-policy-check" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true" "security.deckhouse.io/pod-policy" "restricted" "security.deckhouse.io/pod-policy-action" "warn" "security.deckhouse.io/enable-security-policy-check" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}


### PR DESCRIPTION
## Description

Add the `security.deckhouse.io/pod-policy: restricted`, `security.deckhouse.io/pod-policy-action: warn` and `security.deckhouse.io/enable-security-policy-check: true` labels to the `d8-pod-reloader` namespace, turning on the PSS `restricted` check via admission-policy-engine. The `warn` action reports violations without blocking anything, matching the migration window; the action label is meant to be removed later so the namespace moves to `deny`.

## Why do we need it, and what problem does it solve?

System `d8-*` namespaces are being migrated to PSS `restricted` (platform-wide: `warn` in 1.78, `deny` in 1.79). The pod-reloader Deployment already meets every `restricted` control through the standard helm_lib security-context helpers (non-root, seccomp `RuntimeDefault`, read-only root filesystem, all capabilities dropped, no privilege escalation, no hostPath/host namespaces). Shipping `warn` first keeps the module non-blocking during the window; once the violation metric is confirmed to be zero, dropping the action label switches the namespace to `deny`.

### Manual testing

Verified end-to-end on a dev cluster. This branch was built via the `deploy_dev` workflow and installed with a `ModulePullOverride` pinned to that build, so the running module carries this change.

```console
# The namespace comes up with the three security labels:
$ k get ns d8-pod-reloader --show-labels
d8-pod-reloader   Active   21s   app.kubernetes.io/managed-by=Helm,app=pod-reloader,extended-monitoring.deckhouse.io/enabled=,heritage=deckhouse,kubernetes.io/metadata.name=d8-pod-reloader,module=pod-reloader,prometheus.deckhouse.io/rules-watcher-enabled=true,security.deckhouse.io/enable-security-policy-check=true,security.deckhouse.io/pod-policy-action=warn,security.deckhouse.io/pod-policy=restricted

# The module pod starts and stays healthy:
$ k -n d8-pod-reloader get pods
NAME                            READY   STATUS    RESTARTS   AGE
pod-reloader-6597645865-dvlwj   2/2     Running   0          3m9s

# Gatekeeper audit reports zero violations for the namespace:
$ k get constraints -o json | grep -c '"d8-pod-reloader"'
0

# Admission runs in warn mode and is active — a deliberately non-compliant pod is only warned, not blocked:
$ k -n d8-pod-reloader apply --dry-run=server -f non-compliant-pod.yaml
Warning: [d8-pod-security-restricted-warn-d8] Container bad is attempting to run as disallowed user. | Actual runAsUser: not set, runAsNonRoot: not set | Allowed runAsUser: {"rule": "MustRunAsNonRoot"}
Warning: [d8-pod-security-restricted-warn-d8] Privilege escalation container is not allowed, container: bad | allowPrivilegeEscalation: true | policy allows: false
Warning: [d8-pod-security-restricted-warn-d8] container is not dropping all required capabilities, container: bad | capabilities.drop: [] | policy allows: ["ALL"]
pod/pss-dryrun-bad created (server dry run)

# A pod with the module's own securityContext passes with no warning:
$ k -n d8-pod-reloader apply --dry-run=server -f podreloader-like-pod.yaml
pod/pss-dryrun-good created (server dry run)
```

The module's core function still works on this build — a workload is rolled out when a referenced ConfigMap changes. A Deployment annotated with `pod-reloader.deckhouse.io/auto: "true"` referenced a ConfigMap; changing that ConfigMap triggered a rollout:

```console
# Change the referenced ConfigMap:
$ k -n reload-test patch configmap reload-test-cm --type merge -p '{"data":{"KEY":"v2"}}'
configmap/reload-test-cm patched

# Reloader rolls the Deployment out — a new ReplicaSet appears within seconds:
$ k -n reload-test get rs
NAME                     DESIRED   CURRENT   READY   AGE
reload-test-6c46cd6d77   1         1         1       41s
reload-test-6c5d954b8c   1         1         0       1s

# Reloader's own log confirms it detected the change and triggered the rollout:
$ k -n d8-pod-reloader logs deploy/pod-reloader -c manager
{"level":"info","msg":"Changes detected in 'reload-test-cm' of type 'CONFIGMAP' in namespace 'reload-test'; updated 'reload-test' of type 'Deployment' in namespace 'reload-test'"}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
