### PR TITLE
[pod-reloader] Add more metadata to release image

### DIFF
--- a/.werf/release.yaml
+++ b/.werf/release.yaml
@@ -10,3 +10,9 @@ import:
       - version.json
       - changelog.yaml
       - module.yaml
+      - crds
+      - docs
+  - image: choose-edition
+    add: /openapi
+    to: /openapi
+    after: install

--- a/.werf/release.yaml
+++ b/.werf/release.yaml
@@ -10,9 +10,13 @@ import:
       - version.json
       - changelog.yaml
       - module.yaml
-      - crds
-      - docs
   - image: choose-edition
     add: /openapi
     to: /openapi
     after: install
+git:
+  - add: /
+    to: /
+    includePaths:
+      - crds
+      - docs

--- a/.werf/release.yaml
+++ b/.werf/release.yaml
@@ -18,5 +18,4 @@ git:
   - add: /
     to: /
     includePaths:
-      - crds
       - docs


### PR DESCRIPTION
## Description
Added a new paths to release image:
- docs
- openapi

Result:
```bash
d8 cr fs ls dev-registry.deckhouse.io/sys/deckhouse-oss/modules/pod-reloader/release:pr25

.werf/
.werf/archive/
.werf/scripts/
.werf/stapel/
changelog.yaml
docs/
docs/CONFIGURATION.md
docs/CONFIGURATION.ru.md
docs/EXAMPLES.md
docs/EXAMPLES.ru.md
docs/README.md
docs/README.ru.md
module.yaml
openapi/
openapi/config-values.yaml
openapi/doc-ru-config-values.yaml
openapi/openapi-case-tests.yaml
openapi/values.yaml
version.json

```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
